### PR TITLE
Changed the task name to be snake-cased

### DIFF
--- a/tasks/multibundle-requirejs.js
+++ b/tasks/multibundle-requirejs.js
@@ -25,7 +25,7 @@ var path      = require('path')
 module.exports = task = function(grunt)
 {
   grunt.registerTask(
-    'multibundle-requirejs',
+    'multibundle_requirejs',
     'Grunt task for handling multi-bundle requirejs setup',
     partial(task._multibundleRequirejs, grunt)
   );

--- a/test/test-task.js
+++ b/test/test-task.js
@@ -15,7 +15,7 @@ buster.testCase('task',
 
   'registers task with provided grunt instance': function()
   {
-    assert.calledOnceWith(this.grunt.registerTask, 'multibundle-requirejs');
+    assert.calledOnceWith(this.grunt.registerTask, 'multibundle_requirejs');
     assert.isFunction(this.grunt.registerTask.getCall(0).args[2]);
   }
 });


### PR DESCRIPTION
# What/Why

Changed the task name to be snake-cased.

This now matches the example in the README and it also makes it easier to deal with in the gruntfile as the alternative is to quote the name because it previously had a hyphen.

# How Tested

Updated tests and ran `npm test`
