### PR TITLE
Changed the README to match the task name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In your project's Gruntfile, add a section named `multibundle_requirejs` to the 
 
 ```js
 grunt.initConfig({
-  multibundle_requirejs: {
+  'multibundle-requirejs': {
     options: {
       _config: {
         // task "global" options


### PR DESCRIPTION
# What/Why

The documentation didn't match the name of the task, so if anyone tried to use `multibundle_requirejs` it would give an error.

# How Tested

Ran `npm test` and manually tested.

