### PR TITLE
Armored received mapper instance

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,21 @@
 var assert = require('assert');
 var expectedBundles = 4;
 
+function testBuild(options, buildObject)
+{
+  // it will be invoked for each bundle with respective buildObject
+  if (buildObject)
+  {
+    assert(buildObject.name in options);
+    expectedBundles--;
+  }
+  // and without arguments after all bundles have been processed
+  else
+  {
+    assert.strictEqual(0, expectedBundles);
+  }
+}
+
 module.exports = function(grunt)
 {
   var options;
@@ -43,21 +58,15 @@ module.exports = function(grunt)
           sharedBundles: ['optional', 'common'],
           // or custom function `hashFiles(output, componentOptions)`
           hashFiles: true,
-          // will be called one extra time with no arguments after all the bundles processed
-          // also accepts writable streams in object mode, (e.g. `multibundle-requirejs-mapping-write`)
-          handleMapping: function(buildObject)
+          // should be a function that returns
+          // mapper instance (receiving function or writable stream)
+          // Note: it needs to be wrapper into a function
+          // to prevent grunt messing up with the object's state
+          handleMapping: function(options, grunt)
           {
-            // it will be invoked for each bundle with respective buildObject
-            if (buildObject)
-            {
-              assert(buildObject.name in options['multibundle-requirejs'].options);
-              expectedBundles--;
-            }
-            // and without arguments after all bundles have been processed
-            else
-            {
-              assert.strictEqual(0, expectedBundles);
-            }
+            // will be called one extra time with no arguments after all the bundles processed
+            // also accepts writable streams in object mode, (e.g. `multibundle-mapper`)
+            return testBuild.bind(null, options);
           },
           // pass options to r.js
           baseUrl: '.',

--- a/README.md
+++ b/README.md
@@ -88,13 +88,16 @@ If enabled adds md5 hash (over bundle's content) to the bundle's filename.
 Could be a function (`hashFiles(output, componentOptions)`), then it will be responsible for producing content hash.
 
 #### _config.handleMapping
-Type: `WriteStream|Function`
-Default value: `undefined`
+Type: `Function`
 
-Will be called after each bundle creation with respective `buildObject`,
+Accepts two arguments `options` - options object passed to the grunt task,
+and `grunt` - grunt instance itself.
+
+Expected to return mapper instance, either `WriteStream` or a function,
+that will be called after each bundle creation with respective `buildObject`,
 to allow modules-bundle mapping. Will be called one extra time with no arguments
 after all the bundles processed. In case of WriteStream, bundler's ReadStream will piped into it.
-For example of the mapping write stream, see `multibundle-requirejs-mapping-write`.
+For example of the mapping write stream, see [multibundle-mapper](https://www.npmjs.com/package/multibundle-mapper).
 
 #### _config.baseUrl
 Type: `String`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-multibundle-requirejs",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Grunt task for handling multi-bundle requirejs setup",
   "main": "tasks/multibundle-requirejs.js",
   "scripts": {


### PR DESCRIPTION
Grunt is messing up with objects passed in options, protecting it by wrapping into a function.

Again, need it for beaker, so auto-merging.